### PR TITLE
feat: add docker setup with mock backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+mock-backend/node_modules
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Stage 1: install dependencies
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+
+# Stage 2: build application
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# Stage 3: production image
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/package*.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/next.config.ts ./next.config.ts
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.9"
+
+services:
+  frontend:
+    build: .
+    environment:
+      NODE_ENV: production
+      BACKEND_URL: http://mock-backend:3001
+    ports:
+      - "3000:3000"
+    depends_on:
+      - mock-backend
+    profiles:
+      - prod
+
+  frontend-dev:
+    build: .
+    command: npm run dev
+    environment:
+      NODE_ENV: development
+      BACKEND_URL: http://mock-backend:3001
+    volumes:
+      - .:/app
+      - /app/node_modules
+    ports:
+      - "3000:3000"
+    depends_on:
+      - mock-backend
+    profiles:
+      - dev
+
+  mock-backend:
+    build: ./mock-backend
+    environment:
+      PORT: 3001
+    ports:
+      - "3001:3001"
+    profiles:
+      - dev
+      - prod

--- a/mock-backend/.dockerignore
+++ b/mock-backend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/mock-backend/Dockerfile
+++ b/mock-backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY server.js ./
+ENV PORT=3001
+EXPOSE 3001
+CMD ["node", "server.js"]

--- a/mock-backend/package.json
+++ b/mock-backend/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "mock-backend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/mock-backend/server.js
+++ b/mock-backend/server.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3001;
+
+app.get('/api/virtual-machines', (req, res) => {
+  res.json([{ id: 1, name: 'vm1', status: 'running' }]);
+});
+
+app.listen(port, () => {
+  console.log(`Mock backend listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for Next.js app
- docker-compose with dev/prod profiles and mock backend
- express mock backend to simulate Proxmox

## Testing
- `npm test`
- `npm run lint`
- `docker-compose --profile dev up --build -d` *(fails: Error while fetching server API version)*

------
https://chatgpt.com/codex/tasks/task_e_689678d2a9d8832b9d32a3f121624b2b