### PR TITLE
Add authentication utilities and admin route guard

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from "react"
+import { redirect } from "next/navigation"
+import { getUser } from "@/lib/auth"
+import { can } from "@/lib/rbac"
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  const user = getUser()
+  if (!user || !can("admin", user.role)) {
+    redirect("/")
+  }
+  return <>{children}</>
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminPage() {
+  return <div>Admin dashboard</div>
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,89 @@
+import { cookies } from "next/headers"
+import type { Role } from "./rbac"
+
+const API_BASE = process.env.NEXT_PUBLIC_AUTH_API || ""
+
+export interface User {
+  id: string
+  email: string
+  role: Role
+}
+
+export interface AuthResponse {
+  user: User
+  accessToken: string
+  refreshToken: string
+}
+
+const ACCESS_TOKEN = "access_token"
+const REFRESH_TOKEN = "refresh_token"
+const USER_COOKIE = "user"
+
+function setSession(data: AuthResponse) {
+  const cookieStore = cookies()
+  cookieStore.set(ACCESS_TOKEN, data.accessToken, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+  })
+  cookieStore.set(REFRESH_TOKEN, data.refreshToken, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+  })
+  cookieStore.set(USER_COOKIE, JSON.stringify(data.user), {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+  })
+}
+
+export async function login(email: string, password: string) {
+  const res = await fetch(`${API_BASE}/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  })
+
+  if (!res.ok) {
+    throw new Error("Login failed")
+  }
+
+  const data = (await res.json()) as AuthResponse
+  setSession(data)
+  return data.user
+}
+
+export async function refreshToken() {
+  const refresh = cookies().get(REFRESH_TOKEN)?.value
+  if (!refresh) {
+    throw new Error("No refresh token")
+  }
+
+  const res = await fetch(`${API_BASE}/refresh`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ refreshToken: refresh }),
+  })
+
+  if (!res.ok) {
+    throw new Error("Refresh token failed")
+  }
+
+  const data = (await res.json()) as {
+    accessToken: string
+    refreshToken: string
+    user?: User
+  }
+
+  setSession({
+    accessToken: data.accessToken,
+    refreshToken: data.refreshToken,
+    user: data.user || getUser()!,
+  })
+}
+
+export function getUser(): User | null {
+  const value = cookies().get(USER_COOKIE)?.value
+  return value ? (JSON.parse(value) as User) : null
+}

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -1,0 +1,10 @@
+export type Role = "USER" | "ADMIN"
+
+const permissions: Record<Role, string[]> = {
+  USER: [],
+  ADMIN: ["admin"],
+}
+
+export function can(action: string, role?: Role) {
+  return !!role && permissions[role]?.includes(action)
+}

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand"
+import type { User } from "@/lib/auth"
+
+interface UserState {
+  user: User | null
+  setUser: (user: User | null) => void
+}
+
+export const useUserStore = create<UserState>((set) => ({
+  user: null,
+  setUser: (user) => set({ user }),
+}))


### PR DESCRIPTION
## Summary
- add auth helper with login & refresh token stored in HTTP-only cookies
- implement simple RBAC and Zustand user session store
- protect /admin/* routes via server-side layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689680c25148832bbe8be2cae6f2dc08