### PR TITLE
feat: add toast system and theme switch

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { MockProvider } from "../mocks/MockProvider";
+import { Topbar } from "@/components/Topbar";
+import { Toaster } from "@/components/Toaster";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,7 +31,9 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <MockProvider />
+        <Topbar />
         {children}
+        <Toaster />
       </body>
     </html>
   );

--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useToastStore } from "@/stores/toast";
+
+export function Toaster() {
+  const toasts = useToastStore((state) => state.toasts);
+
+  return (
+    <div className="fixed top-4 right-4 flex flex-col gap-2 z-50">
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          className="rounded bg-gray-800 text-white px-4 py-2 shadow"
+        >
+          <p className="font-medium">{toast.title}</p>
+          {toast.description && (
+            <p className="text-sm opacity-80">{toast.description}</p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Topbar.tsx
+++ b/src/components/Topbar.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { useThemeStore } from "@/stores/theme";
+
+export function Topbar() {
+  const theme = useThemeStore((state) => state.theme);
+  const toggleTheme = useThemeStore((state) => state.toggleTheme);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+  }, [theme]);
+
+  return (
+    <header className="w-full border-b p-4 flex justify-end">
+      <button
+        onClick={toggleTheme}
+        className="px-3 py-1 rounded border"
+        aria-label="Toggle theme"
+      >
+        {theme === "dark" ? "Light" : "Dark"}
+      </button>
+    </header>
+  );
+}

--- a/src/hooks/useConfirm.ts
+++ b/src/hooks/useConfirm.ts
@@ -1,0 +1,7 @@
+"use client";
+
+import { useCallback } from "react";
+
+export function useConfirm(message: string) {
+  return useCallback(() => window.confirm(message), [message]);
+}

--- a/src/hooks/usePolling.ts
+++ b/src/hooks/usePolling.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+export function usePolling(callback: () => void, interval: number, enabled = true) {
+  const savedCallback = useRef(callback);
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    if (!enabled || interval <= 0) return;
+
+    const id = setInterval(() => {
+      savedCallback.current();
+    }, interval);
+
+    return () => clearInterval(id);
+  }, [interval, enabled]);
+}

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useCallback } from "react";
+import { useToastStore, Toast } from "@/stores/toast";
+
+interface ToastOptions extends Omit<Toast, "id"> {
+  duration?: number;
+}
+
+export function useToast() {
+  const addToast = useToastStore((state) => state.addToast);
+  const removeToast = useToastStore((state) => state.removeToast);
+
+  const toast = useCallback(
+    ({ duration = 3000, ...rest }: ToastOptions) => {
+      const id = addToast(rest);
+      if (duration > 0) {
+        setTimeout(() => removeToast(id), duration);
+      }
+      return id;
+    },
+    [addToast, removeToast]
+  );
+
+  return { toast };
+}

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -1,0 +1,16 @@
+import { create } from "zustand";
+
+export type Theme = "light" | "dark";
+
+interface ThemeState {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+}
+
+export const useThemeStore = create<ThemeState>((set) => ({
+  theme: "light",
+  setTheme: (theme) => set({ theme }),
+  toggleTheme: () =>
+    set((state) => ({ theme: state.theme === "light" ? "dark" : "light" })),
+}));

--- a/src/stores/toast.ts
+++ b/src/stores/toast.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+
+export type ToastType = "info" | "success" | "error";
+
+export interface Toast {
+  id: string;
+  title: string;
+  description?: string;
+  type?: ToastType;
+}
+
+interface ToastState {
+  toasts: Toast[];
+  addToast: (toast: Omit<Toast, "id">) => string;
+  removeToast: (id: string) => void;
+  clear: () => void;
+}
+
+export const useToastStore = create<ToastState>((set) => ({
+  toasts: [],
+  addToast: (toast) => {
+    const id = Math.random().toString(36).slice(2);
+    set((state) => ({ toasts: [...state.toasts, { ...toast, id }] }));
+    return id;
+  },
+  removeToast: (id) =>
+    set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) })),
+  clear: () => set({ toasts: [] }),
+}));


### PR DESCRIPTION
## Summary
- add Zustand stores for toast messages and theme
- implement useToast, useConfirm and usePolling hooks
- include Toaster component and topbar theme toggle in layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68968201c328832ba0c74b098cea3e82