### PR TITLE
chore: remove compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   frontend:
     build: .


### PR DESCRIPTION
## Summary
- drop the now-unnecessary top-level `version` from `docker-compose.yml`

## Testing
- `npm test`
- `docker compose --profile dev up --build` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68968419a4ec832baddccec906f29048